### PR TITLE
Allow router override (v2.7.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ const service = require('restana')({
 
 ### Configuration
 - `server`: Allows to override the HTTP server instance to be used.
+- `routerFactory`: Router factory function to allow default `find-my-way` router override. 
 - `prioRequestsProcessing`: If `TRUE`, HTTP requests processing/handling is prioritized using `setImmediate`. Default value: `TRUE`
 - `ignoreTrailingSlash`: If `TRUE`, trailing slashes on routes are ignored. Default value: `FALSE`
 - `allowUnsafeRegex`: If `TRUE`, potentially catastrophic exponential-time regular expressions are disabled. Default value: `FALSE`
@@ -45,7 +46,19 @@ const service = require('restana')({
 });
 ```
 
-### Creating the micro-service interface
+#### Providing a router factory method:
+> In this example we use `anumargak` router instead of `find-my-way`.
+```js 
+const anumargak = require('anumargak')
+const service = require('restana')({
+  routerFactory: (options) => {
+    return anumargak(options)
+  }
+})
+...
+```
+
+### Creating a micro-service
 ```js
 const bodyParser = require('body-parser');
 service.use(bodyParser.json());
@@ -86,12 +99,12 @@ Supported HTTP methods:
 const methods = ['get', 'delete', 'put', 'patch', 'post', 'head', 'options', 'trace'];
 ```
 
-### Starting the service
+#### Starting the service
 ```js
 service.start(3000).then((server) => {});
 ```
 
-### Stopping the service
+#### Stopping the service
 ```js
 service.close().then(()=> {});
 ```

--- a/demos/router-factory.js
+++ b/demos/router-factory.js
@@ -1,0 +1,13 @@
+const anumargak = require('anumargak')
+
+const service = require('./../index')({
+  routerFactory: (options) => {
+    console.log('creating anumargak router...')
+    return anumargak(options)
+  }
+})
+
+service.get('/hi', (req, res) => {
+  res.send('Hello World!')
+})
+service.start()

--- a/index.js
+++ b/index.js
@@ -49,8 +49,8 @@ module.exports = (options = {}) => {
     })
   }
 
-  // creating request router instance
-  const router = requestRouter(options)
+  // creating request router instance, considers custom router override
+  const router = options.routerFactory ? options.routerFactory(options) : requestRouter(options)
   // routes holder
   const routes = {}
   // global middlewares holder

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restana",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -108,6 +108,17 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
       "dev": true
+    },
+    "anumargak": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/anumargak/-/anumargak-2.0.2.tgz",
+      "integrity": "sha512-mMvIyk02zxU36Isqw/FKq2u3obcV51ge9SaYQDr/QwtCSbRcuUefZTA0Ox4FWhAFOgvD4PMPh44CbDcrDnUObg==",
+      "dev": true,
+      "requires": {
+        "randexp": "^0.4.9",
+        "safe-regex": "^1.1.0",
+        "semver-store": "^0.3.0"
+      }
     },
     "any-promise": {
       "version": "1.3.0",
@@ -779,6 +790,12 @@
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
       "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+      "dev": true
+    },
+    "drange": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/drange/-/drange-1.1.1.tgz",
+      "integrity": "sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==",
       "dev": true
     },
     "dtrace-provider": {
@@ -3031,6 +3048,24 @@
       "dev": true,
       "requires": {
         "fast-safe-stringify": "^1.0.8"
+      }
+    },
+    "randexp": {
+      "version": "0.4.9",
+      "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.9.tgz",
+      "integrity": "sha512-maAX1cnBkzIZ89O4tSQUOF098xjGMC8N+9vuY/WfHwg87THw6odD2Br35donlj5e6KnB1SB0QBHhTQhhDHuTPQ==",
+      "dev": true,
+      "requires": {
+        "drange": "^1.0.0",
+        "ret": "^0.2.0"
+      },
+      "dependencies": {
+        "ret": {
+          "version": "0.2.2",
+          "resolved": "https://registry.npmjs.org/ret/-/ret-0.2.2.tgz",
+          "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
+          "dev": true
+        }
       }
     },
     "range-parser": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restana",
-  "version": "2.6.0",
+  "version": "2.7.0",
   "description": "Super fast and minimalist web framework for building REST micro-services.",
   "main": "index.js",
   "scripts": {
@@ -37,6 +37,7 @@
     "find-my-way": "^1.17.0"
   },
   "devDependencies": {
+    "anumargak": "^2.0.2",
     "chai": "^4.2.0",
     "express": "^4.16.4",
     "fastify": "^1.13.3",

--- a/specs/router-factory.test.js
+++ b/specs/router-factory.test.js
@@ -1,0 +1,31 @@
+/* global describe, it */
+const request = require('supertest')
+
+describe('Router Factory - overriding find-my-way router with "anumargak"', () => {
+  let server
+  const anumargak = require('anumargak')
+
+  const service = require('../index')({
+    routerFactory: (options) => {
+      console.log('creating anumargak router...')
+      return anumargak(options)
+    }
+  })
+  service.get('/hello', (req, res) => {
+    res.send(200)
+  })
+
+  it('should start the service with "anumargak" router', async () => {
+    server = await service.start(~~process.env.PORT)
+  })
+
+  it('should GET 200 on /hello', async () => {
+    await request(server)
+      .get('/hello')
+      .expect(200)
+  })
+
+  it('should successfully terminate the service', async () => {
+    await service.close()
+  })
+})


### PR DESCRIPTION
Adding routerFactory configuration to allow default router override. 
Added example using **anumargak** router, which shares compatibility with **find-my-way**.