### PR TITLE
adding support for .all routes registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ const service = require('restana')({
 ```
 > Please consider that when using `anumargak` router, request params are accessible via: `req._path.params`
 
-### Creating a micro-service
+### Creating a micro-service & routes registration
 ```js
 const bodyParser = require('body-parser');
 service.use(bodyParser.json());
@@ -98,6 +98,14 @@ service.get('/version', function (req, res) {
 Supported HTTP methods:
 ```js
 const methods = ['get', 'delete', 'put', 'patch', 'post', 'head', 'options', 'trace'];
+```
+
+#### Using .all routes registration
+You can also register a route handler for `all` supported HTTP methods:
+```js
+service.all('/allmethodsroute', function (req, res) {
+    res.send(200)
+});
 ```
 
 #### Starting the service

--- a/index.js
+++ b/index.js
@@ -97,7 +97,7 @@ module.exports = (options = {}) => {
       )
 
       // creating routing key
-      const key = `[${method.toUpperCase()}]${path}`
+      const key = `[${method.toString().toUpperCase()}]${path}`
       if (!routes[key]) {
         // caching route arguments
         routes[key] = {
@@ -205,6 +205,9 @@ module.exports = (options = {}) => {
   methods.forEach((method) => {
     app[method] = addRoute(method)
   })
+
+  // exposing "all" HTTP verbs as request routing registration
+  app.all = addRoute(methods)
 
   // integrator callback
   app.callback = () => app.handle

--- a/libs/route-register.js
+++ b/libs/route-register.js
@@ -2,13 +2,20 @@
  * Route registration handler
  *
  * @param {Object} app The restana service instance
- * @param {String} method The request method, i.e: GET, POST...
+ * @param {String} methods The request method, i.e: GET, POST...
  * @param {String} path The request path, i.e: /users/1
  * @param {Array} args The route registration arguments. Includes the handler and it's calling context, plus optional route level middlewares
  */
-module.exports = (app, method, path, args) => {
+module.exports = (app, methods, path, args) => {
   let ctx = {}
   let middlewares = []
+
+  // sanitazing HTTP methods
+  if (Array.isArray(methods)) {
+    methods = methods.map(method => method.toUpperCase())
+  } else {
+    methods = methods.toUpperCase()
+  }
 
   // try handler as last element of the array
   let handler = args.pop()
@@ -33,5 +40,5 @@ module.exports = (app, method, path, args) => {
   }
 
   // register route
-  app.route(method.toUpperCase(), path, handler, ctx, middlewares)
+  app.route(methods, path, handler, ctx, middlewares)
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restana",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restana",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "description": "Super fast and minimalist web framework for building REST micro-services.",
   "main": "index.js",
   "scripts": {

--- a/tests.js
+++ b/tests.js
@@ -55,6 +55,8 @@ describe('Restana Web Framework - Smoke', () => {
     service.get('/handler-override', (req, res) => res.send('1'))
     service.get('/handler-override', (req, res) => res.send('2'))
 
+    service.all('/sheet.css', (req, res) => res.send(200))
+
     server = await service.start(~~process.env.PORT)
   })
 
@@ -127,6 +129,18 @@ describe('Restana Web Framework - Smoke', () => {
       .then((response) => {
         expect(response.text).to.equal('2')
       })
+  })
+
+  it('should receive 200 on /sheet.css using .all registration', async () => {
+    await request(server)
+      .get('/sheet.css')
+      .expect(200)
+    await request(server)
+      .post('/sheet.css')
+      .expect(200)
+    await request(server)
+      .put('/sheet.css')
+      .expect(200)
   })
 
   let errMsg


### PR DESCRIPTION
You can also register a route handler for `all` supported HTTP methods:
```js
service.all('/allmethodsroute', function (req, res) {
    res.send(200)
});
```