### PR TITLE
TypeScript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -4,4 +4,15 @@ declare namespace restana {
     HTTPS = 'https',
     HTTP2 = 'http2'
   }
+
+  enum Method {
+    GET = 'get',
+    DELETE = 'delete',
+    PATCH = 'patch',
+    POST = 'post',
+    PUT = 'put',
+    HEAD = 'head',
+    OPTIONS = 'options',
+    TRACE = 'trace'
+  }
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,18 @@ declare namespace restana {
     ? HttpsServer
     : HttpServer
 
-  interface Options<P extends Protocol> {}
+  interface Router {}
+
+  interface Options<P extends Protocol> {
+    server?: Server<P>
+    routerFactory?(options: Options<P>): Router
+    prioRequestsProcessing?: boolean
+    ignoreTrailingSlash?: boolean
+    allowUnsafeRegex?: boolean
+    maxParamLength?: number
+    defaultRoute?(req: Request<P>, res: Response<P>): void
+    disableResponseEvent?: boolean
+  }
 
   interface Service<P extends Protocol> {}
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -53,7 +53,44 @@ declare namespace restana {
     next: (error?: unknown) => void
   ) => void | Promise<unknown>
 
-  type RegisterRoute<P extends Protocol> = Function
+  interface RegisterRoute<P extends Protocol> {
+    (
+      path: string,
+      handler: RequestHandler<P>,
+      middlewares?: RequestHandler<P>[]
+    ): Service<P>
+
+    (
+      path: string,
+      handler: RequestHandler<P>,
+      context?: {},
+      middlewares?: RequestHandler<P>[]
+    ): Service<P>
+
+    (
+      path: string,
+      middleware1: RequestHandler<P>,
+      handler: RequestHandler<P>,
+      context?: {}
+    ): Service<P>
+
+    (
+      path: string,
+      middleware1: RequestHandler<P>,
+      middleware2: RequestHandler<P>,
+      handler: RequestHandler<P>,
+      context?: {}
+    ): Service<P>
+
+    (
+      path: string,
+      middleware1: RequestHandler<P>,
+      middleware2: RequestHandler<P>,
+      middleware3: RequestHandler<P>,
+      handler: RequestHandler<P>,
+      context?: {}
+    ): Service<P>
+  }
 
   interface Route<P extends Protocol> {
     method: Method

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,11 @@
+import { Server as HttpServer, IncomingMessage, ServerResponse } from 'http'
+import { Server as HttpsServer } from 'https'
+import {
+  Http2SecureServer,
+  Http2ServerRequest,
+  Http2ServerResponse
+} from 'http2'
+
 declare namespace restana {
   enum Protocol {
     HTTP = 'http',
@@ -15,4 +23,18 @@ declare namespace restana {
     OPTIONS = 'options',
     TRACE = 'trace'
   }
+
+  type Request<P extends Protocol> = P extends Protocol.HTTP2
+    ? Http2ServerRequest
+    : IncomingMessage
+
+  type Response<P extends Protocol> = P extends Protocol.HTTP2
+    ? Http2ServerResponse
+    : ServerResponse
+
+  type Server<P extends Protocol> = P extends Protocol.HTTP2
+    ? Http2SecureServer
+    : P extends Protocol.HTTPS
+    ? HttpsServer
+    : HttpServer
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -68,7 +68,7 @@ declare namespace restana {
     ignoreTrailingSlash?: boolean
     allowUnsafeRegex?: boolean
     maxParamLength?: number
-    defaultRoute?(req: Request<P>, res: Response<P>): void
+    defaultRoute?: RequestHandler<P>
     disableResponseEvent?: boolean
   }
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare namespace restana {
+  enum Protocol {
+    HTTP = 'http',
+    HTTPS = 'https',
+    HTTP2 = 'http2'
+  }
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,11 @@ declare namespace restana {
     ? HttpsServer
     : HttpServer
 
-  type RequestHandler<P extends Protocol> = Function
+  type RequestHandler<P extends Protocol> = (
+    req: Request<P>,
+    res: Response<P>,
+    next: (error?: unknown) => void
+  ) => void | Promise<unknown>
 
   type RegisterRoute<P extends Protocol> = Function
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -46,4 +46,14 @@ declare namespace restana {
     : P extends Protocol.HTTPS
     ? HttpsServer
     : HttpServer
+
+  interface Options<P extends Protocol> {}
+
+  interface Service<P extends Protocol> {}
 }
+
+declare function restana<P extends restana.Protocol = restana.Protocol.HTTP>(
+  options?: restana.Options<P>
+): restana.Service<P>
+
+export = restana

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,9 +28,18 @@ declare namespace restana {
     ? Http2ServerRequest
     : IncomingMessage
 
+  interface ResponseExtensions {
+    send(
+      data?: unknown,
+      code?: number,
+      headers?: Record<string, number | string | string[]>,
+      cb?: () => void
+    ): void
+  }
+
   type Response<P extends Protocol> = P extends Protocol.HTTP2
-    ? Http2ServerResponse
-    : ServerResponse
+    ? Http2ServerResponse & ResponseExtensions
+    : ServerResponse & ResponseExtensions
 
   type Server<P extends Protocol> = P extends Protocol.HTTP2
     ? Http2SecureServer

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,6 +47,18 @@ declare namespace restana {
     ? HttpsServer
     : HttpServer
 
+  type RequestHandler<P extends Protocol> = Function
+
+  type RegisterRoute<P extends Protocol> = Function
+
+  interface Route<P extends Protocol> {
+    method: Method
+    path: string
+    handler: RequestHandler<P>
+    ctx: {}
+    middlewares: RequestHandler<P>[]
+  }
+
   interface Router {}
 
   interface Options<P extends Protocol> {
@@ -60,7 +72,31 @@ declare namespace restana {
     disableResponseEvent?: boolean
   }
 
-  interface Service<P extends Protocol> {}
+  interface Service<P extends Protocol> {
+    getConfigOptions(): Options<P>
+    use(middleware: RequestHandler<P>, context?: {}): void
+    route(
+      method: Method,
+      path: string,
+      handler: RequestHandler<P>,
+      ctx?: {},
+      middlewares?: RequestHandler<P>[]
+    ): Route<P>
+    handle(req: Request<P>, res: Response<P>): void
+    start(port?: number, host?: string): Promise<Server<P>>
+    close(): Promise<void>
+    routes(): string[]
+
+    get: RegisterRoute<P>
+    delete: RegisterRoute<P>
+    patch: RegisterRoute<P>
+    post: RegisterRoute<P>
+    put: RegisterRoute<P>
+    head: RegisterRoute<P>
+    options: RegisterRoute<P>
+    trace: RegisterRoute<P>
+    all: RegisterRoute<P>
+  }
 }
 
 declare function restana<P extends restana.Protocol = restana.Protocol.HTTP>(

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "2.12.0",
   "description": "Super fast and minimalist web framework for building REST micro-services.",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "PORT=3000 NODE_ENV=testing npx nyc --check-coverage --lines 95 node ./node_modules/mocha/bin/mocha tests.js specs/*.test.js",
     "postinstall": "node ./libs/tasks/postinstall.js"


### PR DESCRIPTION
This PR adds TypeScript definitions to the package.

It's not perfect but I think it covers most cases. The only thing really missing is the type for the value returned by `routerFactory`. I have no clue what it should be. Also, I am unsure how to add `body` and `params` to the request. I guess they are only present under certain conditions, right? for example, by using a specific middleware?