### PR TITLE
Expose internal http server

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ const service = require('restana')({
 ```js
 // accessing service configuration
 service.getConfigOptions()
+// accessing restana HTTP server instance
+service.getServer()
 ```
 
 #### Example usage:

--- a/index.d.ts
+++ b/index.d.ts
@@ -125,6 +125,7 @@ declare namespace restana {
   }
 
   interface Service<P extends Protocol> {
+    getServer(): Server<P>,
     getConfigOptions(): Options<P>
     use(middleware: RequestHandler<P>, context?: {}): void
     route(

--- a/index.js
+++ b/index.js
@@ -73,6 +73,12 @@ module.exports = (options = {}) => {
   // the "restana" service interface
   const app = {
     /**
+     * HTTP server instance
+     */
+    getServer () {
+      return server
+    },
+    /**
      * Application configuration options reference
      */
     getConfigOptions () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "restana",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restana",
-  "version": "3.0.2",
+  "version": "3.1.0",
   "description": "Super fast and minimalist web framework for building REST micro-services.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/tests.js
+++ b/tests.js
@@ -11,6 +11,7 @@ describe('Restana Web Framework - Smoke', () => {
 
   it('service options are exposed through getServiceOptions', (done) => {
     expect(typeof service.getConfigOptions().server).to.equal('object')
+    expect(service.getConfigOptions().server).to.equal(service.getServer())
     done()
   })
 


### PR DESCRIPTION
`restana` used HTTP server instance is exposed via:
```js
service.getServer()
```