### PR TITLE
Async middleware support + tweaks

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,6 @@ const handlerCall = require('./libs/route-handler-caller')
  */
 const routeRegister = require('./libs/route-register')
 
-
 /**
  * Application instance contructor like function
  *
@@ -67,13 +66,13 @@ module.exports = (options = {}) => {
   }
 
   const lookup = (req, res, next) => {
-    return router.lookup(req, res);
+    return router.lookup(req, res)
   }
   // global middlewares holder
   const globalMiddlewares = [{
     handler: lookup,
     context: {}
-  }];
+  }]
 
   // error handler
   const errorHandler = options.errorHandler || ((err, req, res) => res.send(err))
@@ -101,10 +100,10 @@ module.exports = (options = {}) => {
      */
     use: (middleware, context = {}) => {
       globalMiddlewares.splice(
-        globalMiddlewares.length - 1, 
-        0, 
+        globalMiddlewares.length - 1,
+        0,
         { handler: middleware, context }
-      );
+      )
     },
 
     /**
@@ -143,10 +142,10 @@ module.exports = (options = {}) => {
           context: {},
           handler: handlerCall(handler, ctx, errorHandler) // -> Function
         }
-      ] : [];
-      
+      ] : []
+
       // Allow override of routes, by first removing the old route
-      router.off(method, path);
+      router.off(method, path)
 
       // registering request handler
       router.on(method, path, (req, res, params) => {
@@ -163,7 +162,7 @@ module.exports = (options = {}) => {
         }
       })
 
-      return routes[key];
+      return routes[key]
     },
 
     /**
@@ -194,7 +193,7 @@ module.exports = (options = {}) => {
      * @param {String} host Optional HTTP server binding network interface
      * @returns {Promise}
      */
-    start: (port = 3000, host) => new Promise((resolve, reject) => {      
+    start: (port = 3000, host) => new Promise((resolve, reject) => {
       server.listen(port, host, (err) => {
         if (err) reject(err)
         resolve(server)

--- a/index.js
+++ b/index.js
@@ -32,6 +32,7 @@ const handlerCall = require('./libs/route-handler-caller')
  */
 const routeRegister = require('./libs/route-register')
 
+
 /**
  * Application instance contructor like function
  *
@@ -57,8 +58,6 @@ module.exports = (options = {}) => {
   const router = options.routerFactory ? options.routerFactory(options) : requestRouter(options)
   // routes holder
   const routes = {}
-  // global middlewares holder
-  const middlewares = []
   // routes registration shortcut factory
   const addRoute = (methods) => (path, ...args) => {
     routeRegister(app, methods, path, args)
@@ -66,6 +65,15 @@ module.exports = (options = {}) => {
     // supporting method chaining for routes registration
     return app
   }
+
+  const lookup = (req, res, next) => {
+    return router.lookup(req, res);
+  }
+  // global middlewares holder
+  const globalMiddlewares = [{
+    handler: lookup,
+    context: {}
+  }];
 
   // error handler
   const errorHandler = options.errorHandler || ((err, req, res) => res.send(err))
@@ -92,10 +100,11 @@ module.exports = (options = {}) => {
      * @param {Object} context The middleware invokation context object
      */
     use: (middleware, context = {}) => {
-      middlewares.push({
-        handler: middleware,
-        context
-      })
+      globalMiddlewares.splice(
+        globalMiddlewares.length - 1, 
+        0, 
+        { handler: middleware, context }
+      );
     },
 
     /**
@@ -119,46 +128,42 @@ module.exports = (options = {}) => {
 
       // creating routing key
       const key = `[${method.toString().toUpperCase()}]${path}`
-      if (!routes[key]) {
-        // caching route arguments
-        routes[key] = {
-          method,
-          path,
-          handler,
-          ctx,
-          middlewares
-        }
-
-        // registering request handler
-        router.on(method, path, (req, res, params) => {
-          // populate req.params
-          req.params = params
-          // destructing arguments
-          const { handler, ctx, middlewares } = routes[key]
-
-          if (middlewares.length > 0) {
-            // call route middlewares and route handler
-            next([
-              ...middlewares.slice(0),
-              {
-                context: {},
-                handler: handlerCall(handler, ctx, errorHandler) // -> Function
-              }
-            ], req, res, errorHandler)()
-          } else {
-            // directly call the route handler only
-            // NOTE: we do this to increase performance
-            handlerCall(handler, ctx, errorHandler)(req, res)
-          }
-        })
-      } else {
-        // update route parameters if route exist
-        routes[key].ctx = ctx
-        routes[key].handler = handler
-        routes[key].middlewares = middlewares
+      // caching route arguments
+      routes[key] = {
+        method,
+        path,
+        handler,
+        ctx,
+        middlewares
       }
 
-      return routes[key]
+      const wares = middlewares.length > 0 ? [
+        ...middlewares.slice(0),
+        {
+          context: {},
+          handler: handlerCall(handler, ctx, errorHandler) // -> Function
+        }
+      ] : [];
+      
+      // Allow override of routes, by first removing the old route
+      router.off(method, path);
+
+      // registering request handler
+      router.on(method, path, (req, res, params) => {
+        // populate req.params
+        req.params = params
+
+        if (middlewares.length > 0) {
+          // call route middlewares and route handler
+          return next(wares, req, res, errorHandler)
+        } else {
+          // directly call the route handler only
+          // NOTE: we do this to increase performance
+          return handlerCall(handler, ctx, errorHandler)(req, res)
+        }
+      })
+
+      return routes[key];
     },
 
     /**
@@ -172,17 +177,9 @@ module.exports = (options = {}) => {
       req.originalUrl = req.url
       res.send = exts.response.send(options, req, res)
 
-      if (middlewares.length > 0) {
+      if (globalMiddlewares.length > 1) {
         // call route middlewares and route handler
-        next([
-          ...middlewares.slice(0),
-          {
-            context: {},
-            handler: (req, res, next) => {
-              router.lookup(req, res)
-            }
-          }
-        ], req, res, errorHandler)()
+        next(globalMiddlewares, req, res, errorHandler)
       } else {
         // directly call the request router
         // NOTE: we do this to increase performance
@@ -197,7 +194,7 @@ module.exports = (options = {}) => {
      * @param {String} host Optional HTTP server binding network interface
      * @returns {Promise}
      */
-    start: (port = 3000, host) => new Promise((resolve, reject) => {
+    start: (port = 3000, host) => new Promise((resolve, reject) => {      
       server.listen(port, host, (err) => {
         if (err) reject(err)
         resolve(server)

--- a/libs/middleware-chain.js
+++ b/libs/middleware-chain.js
@@ -6,11 +6,11 @@
  * @param {Object} res
  * @param {Function} errorHandler
  */
-function next(middlewares, req, res, errorHandler, middlewareIndex = 0) {
+function next (middlewares, req, res, errorHandler, middlewareIndex = 0) {
   // retrieve next middleware from chain
-  const middleware = middlewares[middlewareIndex];
+  const middleware = middlewares[middlewareIndex]
 
-  function step(err) {
+  function step (err) {
     if (err) return errorHandler(err, req, res)
     if (res.statusCode === 200 && !res.finished) {
       if (!middleware) return
@@ -23,12 +23,9 @@ function next(middlewares, req, res, errorHandler, middlewareIndex = 0) {
 
   try {
     return middleware.handler.call(middleware.context, req, res, step)
-  }
-  catch (e) {
+  } catch (e) {
     errorHandler(e, req, res)
   }
 }
-
-
 
 module.exports = next

--- a/libs/middleware-chain.js
+++ b/libs/middleware-chain.js
@@ -6,29 +6,29 @@
  * @param {Object} res
  * @param {Function} errorHandler
  */
-const next = (middlewares, req, res, errorHandler) => {
+function next(middlewares, req, res, errorHandler, middlewareIndex = 0) {
   // retrieve next middleware from chain
-  const middleware = middlewares.shift()
+  const middleware = middlewares[middlewareIndex];
 
-  return (err) => {
+  function step(err) {
     if (err) return errorHandler(err, req, res)
     if (res.statusCode === 200 && !res.finished) {
       if (!middleware) return
 
-      try {
-        // invoke each middleware
-        const result = middleware.handler.call(middleware.context, req, res, next(middlewares, req, res, errorHandler))
-        if (result instanceof Promise) {
-          // async support
-          result.catch(err => errorHandler(err, req, res))
-        }
-      } catch (err) {
-        errorHandler(err, req, res)
-      }
+      return next(middlewares, req, res, errorHandler, ++middlewareIndex)
     } else if (!res.finished) {
       res.send(res.statusCode)
     }
   }
+
+  try {
+    return middleware.handler.call(middleware.context, req, res, step)
+  }
+  catch (e) {
+    errorHandler(e, req, res)
+  }
 }
+
+
 
 module.exports = next


### PR DESCRIPTION
@jkyberneees thanks for the feedback in #47 . I failed to account for the difference between global & route level middlewares and should hopefully have sufficiently addressed everything.

I've made some performance tweaks by removing all instances of array modification & copying during runtime outside of the initial route/middleware setup.

Per your original comments

- restana middlewares support is focused on callback based middlewares using next() not async ones. The goal was to re-use existing express and connect middlewares.

I've tested it out to support both non-async like it is today and fully async through the global and route. Express/connect style middlewares should all still be fully compatible with my code changes.

This could provide an alternative method for post-processing of the response that I noticed mentioned in code. You'd simply create a route that returns data, return that data up the chain and in some middleware process that data then send it off via res.send rather than inside of the actual route itself. An example of something akin to that would be https://github.com/spirit-js/spirit-router

- Route middlewares are executed out of the main middlewares chain.

My changes should now support global async middlewares waiting for route middlewares.