### PR TITLE
support single argument to .start

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,8 +62,9 @@ module.exports = (options = {}) => {
       router.lookup(req, res)
     },
 
-    start: (port = 3000, host) => new Promise((resolve, reject) => {
-      server.listen(port, host, (err) => {
+    start: (...args) => new Promise((resolve, reject) => {
+      if (!args || !args.length) args = [3000]
+      server.listen(...args, (err) => {
         if (err) reject(err)
         resolve(server)
       })


### PR DESCRIPTION
To support the alternative net.Server#listen signatures and enable restana to listen on unix sockets:

- https://nodejs.org/api/net.html#net_server_listen_handle_backlog_callback
- https://nodejs.org/api/net.html#net_server_listen_path_backlog_callback
- https://nodejs.org/api/net.html#net_server_listen_options_callback