### PR TITLE
adding routes method

### DIFF
--- a/demos/get-routes.js
+++ b/demos/get-routes.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const service = require('../index')({})
+
+// the /v1/welcome route handler
+service.get('/routes', (req, res) => {
+  res.send(service.routes())
+})
+
+// start the server
+service.start()

--- a/index.d.ts
+++ b/index.d.ts
@@ -138,6 +138,7 @@ declare namespace restana {
   }
 
   interface Service<P extends Protocol> extends Router<P> {
+    routes(): string[],
     getRouter(): Router<P>,
     newRouter(): Router<P>
     errorHandler: ErrorHandler<P>,

--- a/index.js
+++ b/index.js
@@ -17,6 +17,8 @@ module.exports = (options = {}) => {
   options.errorHandler = options.errorHandler || ((err, req, res) => {
     res.send(err)
   })
+
+  const routes = new Set()
   const router = requestRouter(options)
   const server = options.server || require('http').createServer()
   const prp = undefined === options.prioRequestsProcessing ? true : options.prioRequestsProcessing
@@ -31,6 +33,10 @@ module.exports = (options = {}) => {
   }
 
   const app = {
+    routes () {
+      return [...routes]
+    },
+
     getRouter () {
       return router
     },
@@ -81,6 +87,7 @@ module.exports = (options = {}) => {
 
   shortcuts.forEach((method) => {
     app[method] = (...args) => {
+      routes.add(`${method.toUpperCase()}${args[0]}`)
       router[method].apply(router, args)
 
       return app

--- a/specs/smoke.test.js
+++ b/specs/smoke.test.js
@@ -59,6 +59,11 @@ describe('Restana Web Framework - Smoke', () => {
     server = await service.start(~~process.env.PORT)
   })
 
+  it('routes should exist on service', async () => {
+    expect(service.routes().includes('GET/async/:name')).to.equal(true)
+    expect(service.routes().includes('ALL/sheet.css')).to.equal(true)
+  })
+
   it('should GET JSON response /pets/:id', async () => {
     await request(server)
       .get('/pets/0')


### PR DESCRIPTION
**Added:**
- Re-adding `routes()` method to expose registered first level routes.

  Expected format:
  ```js
  [
     "GET/person/:id",
     "DELETE/person/:id",
     "GET/health"
  ]
  ```

