### PR TITLE
Additional response ext tests

### DIFF
--- a/libs/response-extensions.js
+++ b/libs/response-extensions.js
@@ -9,7 +9,7 @@ const TYPE_OCTET = 'application/octet-stream'
 
 const NOOP = () => {}
 
-const stringify = (obj) => {
+const stringify = obj => {
   // ToDo: fast json stringify ?
   return JSON.stringify(obj)
 }
@@ -21,9 +21,9 @@ const preEnd = (res, contentType, statusCode) => {
   res.statusCode = statusCode
 }
 
-const parseErr = (error) => {
+const parseErr = error => {
   const errorCode = error.status || error.code || error.statusCode
-  const statusCode = typeof errorCode === 'number' ? parseInt(errorCode) : 500
+  const statusCode = typeof errorCode === 'number' ? errorCode : 500
 
   return {
     statusCode,

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -4,6 +4,7 @@
 const request = require('supertest')
 const { createReadStream, readFileSync } = require('fs')
 const path = require('path')
+const stream = require('stream')
 
 describe('All Responses', () => {
   let server
@@ -13,12 +14,17 @@ describe('All Responses', () => {
     res.send('Hello World!')
   })
 
+  service.get('/html-string', (req, res) => {
+    res.setHeader('content-type', 'text/html; charset=utf-8')
+    res.send('<p>Hello World!</p>')
+  })
+
   service.get('/buffer', (req, res) => {
     res.send(Buffer.from('Hello World!'))
   })
 
   service.get('/buffer-string', (req, res) => {
-    res.setHeader('content-type', 'text/plan; charset=utf-8')
+    res.setHeader('content-type', 'text/plain; charset=utf-8')
     res.send(Buffer.from('Hello World!'))
   })
 
@@ -26,9 +32,31 @@ describe('All Responses', () => {
     res.send({ id: 'restana' })
   })
 
+  service.get('/json-with-content-type', (req, res) => {
+    res.setHeader('content-type', 'application/json')
+    res.send({ id: 'restana' })
+  })
+
   service.get('/stream', (req, res) => {
     res.setHeader('content-type', 'text/html; charset=utf-8')
     res.send(createReadStream(path.resolve(__dirname, '../demos/static/src/index.html'), { encoding: 'utf8' }))
+  })
+
+  service.get('/stream-octet', (req, res) => {
+    res.send(
+      stream.Readable.from(
+        (async function * generateTinyStream () {
+          yield 'Hello '
+          yield 'World!'
+        })()
+      )
+    )
+  })
+
+  service.get('/invalid-body', (req, res) => {
+    res.body = true
+    res.setHeader('content-type', 'text/plain; charset=utf-8')
+    res.send()
   })
 
   service.get('/error', (req, res) => {
@@ -45,7 +73,16 @@ describe('All Responses', () => {
     await request(server)
       .get('/string')
       .expect(200)
+      .expect('content-type', 'text/plain; charset=utf-8')
       .expect('Hello World!')
+  })
+
+  it('should GET 200 and html content on /html-string', async () => {
+    await request(server)
+      .get('/html-string')
+      .expect(200)
+      .expect('content-type', 'text/html; charset=utf-8')
+      .expect('<p>Hello World!</p>')
   })
 
   it('should GET 200 and buffer content on /buffer', async () => {
@@ -60,6 +97,7 @@ describe('All Responses', () => {
     await request(server)
       .get('/buffer-string')
       .expect(200)
+      .expect('content-type', 'text/plain; charset=utf-8')
       .expect('Hello World!')
   })
 
@@ -71,12 +109,33 @@ describe('All Responses', () => {
       .expect({ id: 'restana' })
   })
 
+  it('should GET 200 and json content on /json-with-content-type', async () => {
+    await request(server)
+      .get('/json-with-content-type')
+      .expect(200)
+      .expect('content-type', 'application/json')
+      .expect({ id: 'restana' })
+  })
+
   it('should GET 200 and buffer content on /stream', async () => {
     await request(server)
       .get('/stream')
       .expect(200)
       .expect('content-type', 'text/html; charset=utf-8')
       .expect(readFileSync(path.resolve(__dirname, '../demos/static/src/index.html'), 'utf8'))
+  })
+
+  it('should GET 200 and buffer content on /stream-octet', async () => {
+    await request(server)
+      .get('/stream-octet')
+      .expect(200)
+      .expect('content-type', 'application/octet-stream')
+  })
+
+  it('should GET 500 and buffer content on /invalid-body', async () => {
+    await request(server)
+      .get('/invalid-body')
+      .expect(500)
   })
 
   it('should GET 501 and json content on /error', async () => {


### PR DESCRIPTION
Just bringing the coverage for response-extensions to 100%.
Also removed a what I am assuming is a redundant parseInt, similar to the one removed in the previous pr.

Also, I noticed in the options interface, there is an r missing in prior, is that intentional?
I'm guessing fixing it now would be breaking?

![before](https://user-images.githubusercontent.com/9139938/83144863-8fca1180-a0b9-11ea-9461-7cee581ed4ca.png)

![after ](https://user-images.githubusercontent.com/9139938/83144974-b12afd80-a0b9-11ea-968b-99f87804dab1.png)

![cases](https://user-images.githubusercontent.com/9139938/83145003-bf791980-a0b9-11ea-9d55-91773c126e6d.png)
