### PR TITLE
Add unit tests, perf tests, and functionality for send(<Promise>)

### DIFF
--- a/libs/response-extensions.js
+++ b/libs/response-extensions.js
@@ -80,6 +80,7 @@ module.exports.send = (options, req, res) => {
 
             return
           } else if (Promise.resolve(data) === data) { // http://www.ecma-international.org/ecma-262/6.0/#sec-promise.resolve
+            headers = null;
             return data
               .then(resolved => send(resolved, code, headers, cb))
               .catch(err => send(err, code, headers, cb))

--- a/libs/response-extensions.js
+++ b/libs/response-extensions.js
@@ -40,7 +40,7 @@ const parseErr = error => {
  * No comments needed ;)
  */
 module.exports.send = (options, req, res) => {
-  return (data = 200, code = 200, headers = null, cb = NOOP) => {
+  const send = (data = 200, code = 200, headers = null, cb = NOOP) => {
     let contentType
 
     if (data instanceof Error) {
@@ -79,6 +79,10 @@ module.exports.send = (options, req, res) => {
             data.on('end', cb)
 
             return
+          } else if (Promise.resolve(data) === data) { // http://www.ecma-international.org/ecma-262/6.0/#sec-promise.resolve
+            return data
+              .then(resolved => send(resolved, code, headers, cb))
+              .catch(err => send(err, code, headers, cb))
           } else {
             if (!contentType) contentType = TYPE_JSON
             data = stringify(data)
@@ -90,4 +94,6 @@ module.exports.send = (options, req, res) => {
     preEnd(res, contentType, code)
     res.end(data, cb)
   }
+
+  return send
 }

--- a/libs/response-extensions.js
+++ b/libs/response-extensions.js
@@ -80,7 +80,7 @@ module.exports.send = (options, req, res) => {
 
             return
           } else if (Promise.resolve(data) === data) { // http://www.ecma-international.org/ecma-262/6.0/#sec-promise.resolve
-            headers = null;
+            headers = null
             return data
               .then(resolved => send(resolved, code, headers, cb))
               .catch(err => send(err, code, headers, cb))

--- a/performance/suites/res-send.js
+++ b/performance/suites/res-send.js
@@ -19,6 +19,7 @@ const stream = {
   pipe () {},
   on () {}
 }
+const promise = Promise.resolve(buffer);
 const headers = {
   'content-type': 'text/plain',
   'x-framework': 'restana',
@@ -58,6 +59,12 @@ suite
   })
   .add('stream', function () {
     send(stream)
+  })
+  .add('promise', function() {
+    send(promise)
+  })
+  .add('promise + headers', function() {
+    send(promise, 200, headers)
   })
   .on('complete', function () {
     report(this)

--- a/performance/suites/res-send.js
+++ b/performance/suites/res-send.js
@@ -19,7 +19,7 @@ const stream = {
   pipe () {},
   on () {}
 }
-const promise = Promise.resolve(buffer);
+const promise = Promise.resolve(buffer)
 const headers = {
   'content-type': 'text/plain',
   'x-framework': 'restana',
@@ -60,10 +60,10 @@ suite
   .add('stream', function () {
     send(stream)
   })
-  .add('promise', function() {
+  .add('promise', function () {
     send(promise)
   })
-  .add('promise + headers', function() {
+  .add('promise + headers', function () {
     send(promise, 200, headers)
   })
   .on('complete', function () {

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -64,8 +64,8 @@ describe('All Responses', () => {
   })
 
   service.get('/promise-rejected', (req, res) => {
-    const error = new Error('Rejected');
-    error.code = 503;
+    const error = new Error('Rejected')
+    error.code = 503
     res.setHeader('content-type', 'text/html')
     res.send(Promise.reject(error))
   })
@@ -170,7 +170,7 @@ describe('All Responses', () => {
     await request(server)
       .get('/promise-rejected')
       .expect(503)
-      .expect({ code : 503, message: 'Rejected' })
+      .expect({ code: 503, message: 'Rejected' })
       .expect('content-type', 'application/json; charset=utf-8')
   })
 

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -53,6 +53,23 @@ describe('All Responses', () => {
     )
   })
 
+  service.get('/promise', (req, res) => {
+    res.send(Promise.resolve({ hello: 'world' }))
+  })
+
+  service.get('/promise-with-headers', (req, res) => {
+    res.setHeader('content-type', 'application/json')
+    res.setHeader('x-framework', 'restana')
+    res.send(Promise.resolve({ hello: 'world' }))
+  })
+
+  service.get('/promise-rejected', (req, res) => {
+    const error = new Error('Rejected');
+    error.code = 503;
+    res.setHeader('content-type', 'text/html')
+    res.send(Promise.reject(error))
+  })
+
   service.get('/invalid-body', (req, res) => {
     res.body = true
     res.setHeader('content-type', 'text/plain; charset=utf-8')
@@ -117,7 +134,7 @@ describe('All Responses', () => {
       .expect({ id: 'restana' })
   })
 
-  it('should GET 200 and buffer content on /stream', async () => {
+  it('should GET 200 and html content on /stream', async () => {
     await request(server)
       .get('/stream')
       .expect(200)
@@ -130,6 +147,31 @@ describe('All Responses', () => {
       .get('/stream-octet')
       .expect(200)
       .expect('content-type', 'application/octet-stream')
+  })
+
+  it('should GET 200 and json content on /promise', async () => {
+    await request(server)
+      .get('/promise')
+      .expect(200)
+      .expect({ hello: 'world' })
+      .expect('content-type', 'application/json; charset=utf-8')
+  })
+
+  it('should GET 200 and json content on /promise-with-headers', async () => {
+    await request(server)
+      .get('/promise-with-headers')
+      .expect(200)
+      .expect({ hello: 'world' })
+      .expect('content-type', 'application/json')
+      .expect('x-framework', 'restana')
+  })
+
+  it('should GET 503 and json content on /promise-rejected', async () => {
+    await request(server)
+      .get('/promise-rejected')
+      .expect(503)
+      .expect({ code : 503, message: 'Rejected' })
+      .expect('content-type', 'application/json; charset=utf-8')
   })
 
   it('should GET 500 and buffer content on /invalid-body', async () => {


### PR DESCRIPTION
```
[
  { name: 'string', mean: 4.8506097215681385e-9 },
  { name: 'null', mean: 4.926731752482904e-9 },
  { name: 'statusCode', mean: 5.062982295320458e-9 },
  { name: 'undefined', mean: 5.068424582622657e-9 },
  { name: 'stream', mean: 3.1459595935626874e-8 },
  { name: 'buffer', mean: 3.170769038300122e-8 },
  { name: 'string + headers', mean: 4.547794321322292e-8 },
  { name: 'json', mean: 2.1784986308221158e-7 },
  { name: 'error', mean: 2.691510629265817e-7 },
  { name: 'json + headers', mean: 2.764156732832716e-7 },
  { name: 'promise', mean: 0.0000010943179714892707 },
  { name: 'promise + headers', mean: 0.000007731414708140137 }
]
```

Relates to the promise extension brought up in #87 