### PR TITLE
Make sure res.send does not override res.statusCode

### DIFF
--- a/libs/response-extensions.js
+++ b/libs/response-extensions.js
@@ -40,7 +40,7 @@ const parseErr = error => {
  * No comments needed ;)
  */
 module.exports.send = (options, req, res) => {
-  const send = (data = 200, code = 200, headers = null, cb = NOOP) => {
+  const send = (data = res.statusCode, code = res.statusCode, headers = null, cb = NOOP) => {
     let contentType
 
     if (data instanceof Error) {

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -14,6 +14,11 @@ describe('All Responses', () => {
     res.send('Hello World!')
   })
 
+  service.get('/string-override-status', (req, res) => {
+    res.statusCode = 250;
+    res.send('Hello World!')
+  })
+
   service.get('/html-string', (req, res) => {
     res.setHeader('content-type', 'text/html; charset=utf-8')
     res.send('<p>Hello World!</p>')
@@ -90,6 +95,14 @@ describe('All Responses', () => {
     await request(server)
       .get('/string')
       .expect(200)
+      .expect('content-type', 'text/plain; charset=utf-8')
+      .expect('Hello World!')
+  })
+
+  it('should GET 250 and string content on /string-override-status', async () => {
+    await request(server)
+      .get('/string-override-status')
+      .expect(250)
       .expect('content-type', 'text/plain; charset=utf-8')
       .expect('Hello World!')
   })


### PR DESCRIPTION
Consider this piece of code:

```js
service.get('/route/', async (req,res)=> {
     res.statusCode = 250; // random 200-range non-existent code
     res.send('something')
})
```

Unfortunately, res.send will override the status code and use 200 as a default. This may be a problem with legacy applications which do not pass the status code directly to res.send

While this is not a critical issue _per se_, since res.send could always be overridden through middleware, I think it is more correct to do this in restana package itself, especially since res.statusCode is 200 by default anyways