### PR TITLE
Accept boolean in res.send

### DIFF
--- a/libs/response-extensions.js
+++ b/libs/response-extensions.js
@@ -57,6 +57,10 @@ module.exports.send = (options, req, res) => {
 
       // NOTE: only retrieve content-type after setting custom headers
       contentType = res.getHeader(CONTENT_TYPE_HEADER)
+      
+      if (typeof data === 'boolean') {
+        data = stringify(data)
+      }
 
       if (typeof data === 'number') {
         code = data

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -123,7 +123,6 @@ describe('All Responses', () => {
     await request(server)
       .get('/boolean')
       .expect(200)
-      .expect('content-type', 'application/octet-stream')
       .expect('true')
   })
 

--- a/specs/send.test.js
+++ b/specs/send.test.js
@@ -23,7 +23,11 @@ describe('All Responses', () => {
     res.setHeader('content-type', 'text/html; charset=utf-8')
     res.send('<p>Hello World!</p>')
   })
-
+  
+  service.get('/boolean', (req, res) => {
+    res.send(true)
+  })
+  
   service.get('/buffer', (req, res) => {
     res.send(Buffer.from('Hello World!'))
   })
@@ -113,6 +117,14 @@ describe('All Responses', () => {
       .expect(200)
       .expect('content-type', 'text/html; charset=utf-8')
       .expect('<p>Hello World!</p>')
+  })
+  
+  it('should GET 200 and send true on /boolean', async () => {
+    await request(server)
+      .get('/boolean')
+      .expect(200)
+      .expect('content-type', 'application/octet-stream')
+      .expect('true')
   })
 
   it('should GET 200 and buffer content on /buffer', async () => {


### PR DESCRIPTION
Ok, I am on a roll :D Sorry for this :D

### Code

```js
service.get('/hi', (req, res) => {
  res.send(true)
})
```

### Response 

```
{
"code":500,
"message":"The \"chunk\" argument must be of type string or an instance of Buffer. Received type boolean (true)"
}
```

### Solution

Stringify if type of data is boolean